### PR TITLE
Removal of platform method `darkmode` implements

### DIFF
--- a/android/src/main/kotlin/com/bruno/system_theme/SystemThemePlugin.kt
+++ b/android/src/main/kotlin/com/bruno/system_theme/SystemThemePlugin.kt
@@ -24,37 +24,17 @@ class SystemThemePlugin: FlutterPlugin, ActivityAware, MethodCallHandler {
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
-    when (call.method) {
-        "SystemTheme.darkMode" -> {
-          when (activity.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)) {
-            Configuration.UI_MODE_NIGHT_YES -> {
-              result.success(true)
-            }
-            Configuration.UI_MODE_NIGHT_NO -> {
-              result.success(false)
-            }
-            Configuration.UI_MODE_NIGHT_UNDEFINED -> {
-              result.success(false)
-            }
-          }
-        }
-        "SystemTheme.accentColor" -> {
-          val accentColor = getDeviceAccentColor(activity)
-          val hexColor = java.lang.String.format("#%06X", 0xFFFFFF and accentColor)
-          val rgb = getRGB(hexColor)
-          result.success(hashMapOf<String, Any?>(
-                  "accent" to hashMapOf<String, Any?>(
-                          "R" to rgb[0],
-                          "G" to rgb[1],
-                          "B" to rgb[2],
-                          "A" to 1
-                  )
-          ))
-        }
-        else -> {
-          result.notImplemented()
-        }
-    }
+    val accentColor = getDeviceAccentColor(activity)
+    val hexColor = java.lang.String.format("#%06X", 0xFFFFFF and accentColor)
+    val rgb = getRGB(hexColor)
+    result.success(hashMapOf<String, Any?>(
+      "accent" to hashMapOf<String, Any?>(
+        R" to rgb[0],
+        "G" to rgb[1],
+        "B" to rgb[2],
+        "A" to 1
+      )
+    ))
   }
 
   private fun getDeviceAccentColor(context: Context) : Int {

--- a/lib/system_theme.dart
+++ b/lib/system_theme.dart
@@ -5,7 +5,6 @@ import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 /// Default system accent color.
 const kDefaultFallbackColor = Color(0xff00b7c3);
 
-const kGetDarkModeMethod = 'SystemTheme.darkMode';
 const kGetSystemAccentColorMethod = 'SystemTheme.accentColor';
 
 /// Platform channel handler for invoking native methods.

--- a/linux/system_theme_plugin.cc
+++ b/linux/system_theme_plugin.cc
@@ -42,31 +42,14 @@ static void system_theme_plugin_handle_method_call(
 
 	const gchar *method = fl_method_call_get_name(method_call);
 
-	if (strcmp(method, "SystemTheme.accentColor") == 0) {
-		FlView *view = fl_plugin_registrar_get_view(self->registrar);
-		FlValue *accentColor = get_accent_color(GTK_WIDGET(view));
-		g_autoptr(FlValue) colors = fl_value_new_map();
+	FlView *view = fl_plugin_registrar_get_view(self->registrar);
+	FlValue *accentColor = get_accent_color(GTK_WIDGET(view));
+	g_autoptr(FlValue) colors = fl_value_new_map();
 
-		fl_value_set_string_take(colors, "accent", accentColor);
-		// other colors here...
+	fl_value_set_string_take(colors, "accent", accentColor);
+	// other colors here...
 
-		response = FL_METHOD_RESPONSE(fl_method_success_response_new(colors));
-
-	} else if (strcmp(method, "SystemTheme.darkMode") == 0) {
-		gboolean darkMode = false;
-
-		g_object_get(gtk_settings_get_default(),
-					 "gtk-application-prefer-dark-theme",
-					 &darkMode,
-					 NULL);
-
-		g_autoptr(FlValue) result = fl_value_new_bool(darkMode);
-		response = FL_METHOD_RESPONSE(fl_method_success_response_new(result));
-
-	} else {
-		response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
-	}
-
+	response = FL_METHOD_RESPONSE(fl_method_success_response_new(colors));
 
 	fl_method_call_respond(method_call, response, nullptr);
 }

--- a/macos/Classes/SystemThemePlugin.swift
+++ b/macos/Classes/SystemThemePlugin.swift
@@ -1,69 +1,39 @@
 import Cocoa
 import FlutterMacOS
 
-private let kAppleInterfaceThemeChangedNotification = "AppleInterfaceThemeChangedNotification"
-private let kAppleInterfaceStyle = "AppleInterfaceStyle"
-private let kAppleInterfaceStyleSwitchesAutomatically = "AppleInterfaceStyleSwitchesAutomatically"
-
 public class SystemThemePlugin: NSObject, FlutterPlugin {
 	public static func register(with registrar: FlutterPluginRegistrar) {
 		let channel = FlutterMethodChannel(name: "system_theme", binaryMessenger: registrar.messenger)
 		let instance = SystemThemePlugin()
 		registrar.addMethodCallDelegate(instance, channel: channel)
 	}
-	
-	func getAppearance(): String {
-        var osAppearance = "Light"
-        if #available(OSX 10.15, *) {
-            let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
-            self.textview.textStorage?.append(NSAttributedString(string: "appearanceDescription: \(appearanceDescription)\n"))
-            if appearanceDescription.contains("dark") {
-                self.osAppearance = "Dark"
-            }
-        } else if #available(OSX 10.14, *) {
-            if let appleInterfaceStyle = UserDefaults.standard.object(forKey: kAppleInterfaceStyle) as? String {
-                self.textview.textStorage?.append(NSAttributedString(string: "appleInterfaceStyle: \(appleInterfaceStyle)\n"))
-                if appleInterfaceStyle.lowercased().contains("dark") {
-                    self.osAppearance = "Dark"
-                }
-            }
-        }
-		return osAppearance;
-    }
 
 	public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-		switch call.method {
-		case "SystemTheme.darkMode":
-			result(getAppearance() == "Dark");
-		case "SystemTheme.accentColor":
-			if #available(macOS 10.14, *) {
-				if let color = NSColor.controlAccentColor.usingColorSpace(.sRGB) {
-					var r: CGFloat = 0;
-					var g: CGFloat = 0;
-					var b: CGFloat = 0;
-					var a: CGFloat = 0;
-					color.getRed(&r, green: &g, blue: &b, alpha: &a);
+		if #available(macOS 10.14, *) {
+			if let color = NSColor.controlAccentColor.usingColorSpace(.sRGB) {
+				var r: CGFloat = 0;
+				var g: CGFloat = 0;
+				var b: CGFloat = 0;
+				var a: CGFloat = 0;
+				color.getRed(&r, green: &g, blue: &b, alpha: &a);
 
-					var map: Dictionary<String, Any> = Dictionary()
-					map["R"] = Int(r * 255);
-					map["G"] = Int(g * 255);
-					map["B"] = Int(b * 255);
-					map["A"] = Int(a * 255);
+				var map: Dictionary<String, Any> = Dictionary()
+				map["R"] = Int(r * 255);
+				map["G"] = Int(g * 255);
+				map["B"] = Int(b * 255);
+				map["A"] = Int(a * 255);
 
-					var colors: Dictionary<String, Any> = Dictionary()
-					colors["accent"] = map;
-					// other colors here
+				var colors: Dictionary<String, Any> = Dictionary()
+				colors["accent"] = map;
+				// other colors here
 
-					result(colors);
+				result(colors);
 
-				} else {
-					result(nil);
-				}
 			} else {
 				result(nil);
 			}
-		default:
-			result(FlutterMethodNotImplemented)
+		} else {
+			result(nil);
 		}
 	}
 }

--- a/macos/Classes/SystemThemePlugin.swift
+++ b/macos/Classes/SystemThemePlugin.swift
@@ -1,18 +1,40 @@
 import Cocoa
 import FlutterMacOS
 
+private let kAppleInterfaceThemeChangedNotification = "AppleInterfaceThemeChangedNotification"
+private let kAppleInterfaceStyle = "AppleInterfaceStyle"
+private let kAppleInterfaceStyleSwitchesAutomatically = "AppleInterfaceStyleSwitchesAutomatically"
+
 public class SystemThemePlugin: NSObject, FlutterPlugin {
 	public static func register(with registrar: FlutterPluginRegistrar) {
 		let channel = FlutterMethodChannel(name: "system_theme", binaryMessenger: registrar.messenger)
 		let instance = SystemThemePlugin()
 		registrar.addMethodCallDelegate(instance, channel: channel)
 	}
+	
+	func getAppearance(): String {
+        var osAppearance = "Light"
+        if #available(OSX 10.15, *) {
+            let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
+            self.textview.textStorage?.append(NSAttributedString(string: "appearanceDescription: \(appearanceDescription)\n"))
+            if appearanceDescription.contains("dark") {
+                self.osAppearance = "Dark"
+            }
+        } else if #available(OSX 10.14, *) {
+            if let appleInterfaceStyle = UserDefaults.standard.object(forKey: kAppleInterfaceStyle) as? String {
+                self.textview.textStorage?.append(NSAttributedString(string: "appleInterfaceStyle: \(appleInterfaceStyle)\n"))
+                if appleInterfaceStyle.lowercased().contains("dark") {
+                    self.osAppearance = "Dark"
+                }
+            }
+        }
+		return osAppearance;
+    }
 
 	public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
 		switch call.method {
 		case "SystemTheme.darkMode":
-			let type = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") ?? "Light"
-			result(type == "Dark");
+			result(getAppearance() == "Dark");
 		case "SystemTheme.accentColor":
 			if #available(macOS 10.14, *) {
 				if let color = NSColor.controlAccentColor.usingColorSpace(.sRGB) {

--- a/system_theme_web/lib/system_theme_web.dart
+++ b/system_theme_web/lib/system_theme_web.dart
@@ -21,35 +21,26 @@ class SystemThemeWeb {
   /// Note: Check the "federated" architecture for a new way of doing this:
   /// https://flutter.dev/go/federated-plugins
   Future<dynamic> handleMethodCall(MethodCall call) async {
-    switch (call.method) {
-      case 'SystemTheme.darkMode':
-        return html.window.matchMedia('(prefers-color-scheme: dark)').matches;
-      case 'SystemTheme.accentColor':
-        final e = html.document.body;
-        final currentBackgroundColor = e?.style.backgroundColor;
-        e?.style.backgroundColor = "highlight";
-        String? backgroundColor = e?.getComputedStyle().backgroundColor;
-        e?.style.backgroundColor = currentBackgroundColor;
-        if (backgroundColor != null) {
-          backgroundColor = backgroundColor
-              .replaceAll('rgb(', '')
-              .replaceAll(')', '')
-              .replaceAll(' ', '');
-          final rgb = backgroundColor.split(',');
-          return {
-            'accent': {
-              'R': int.parse(rgb[0]),
-              'G': int.parse(rgb[1]),
-              'B': int.parse(rgb[2]),
-            }
-          };
+    final e = html.document.body;
+    final currentBackgroundColor = e?.style.backgroundColor;
+    e?.style.backgroundColor = "highlight";
+    String? backgroundColor = e?.getComputedStyle().backgroundColor;
+    e?.style.backgroundColor = currentBackgroundColor;
+    if (backgroundColor != null) {
+      backgroundColor = backgroundColor
+        .replaceAll('rgb(', '')
+        .replaceAll(')', '')
+        .replaceAll(' ', '');
+    final rgb = backgroundColor.split(',');
+      return {
+        'accent': {
+          'R': int.parse(rgb[0]),
+          'G': int.parse(rgb[1]),
+          'B': int.parse(rgb[2]),
         }
-        return null;
-      default:
-        throw PlatformException(
-          code: 'Unimplemented',
-          details: 'system_theme for web doesn\'t implement \'${call.method}\'',
-        );
+      };
     }
+    
+    return null;
   }
 }

--- a/system_theme_web/lib/system_theme_web.dart
+++ b/system_theme_web/lib/system_theme_web.dart
@@ -28,10 +28,10 @@ class SystemThemeWeb {
     e?.style.backgroundColor = currentBackgroundColor;
     if (backgroundColor != null) {
       backgroundColor = backgroundColor
-        .replaceAll('rgb(', '')
-        .replaceAll(')', '')
-        .replaceAll(' ', '');
-    final rgb = backgroundColor.split(',');
+          .replaceAll('rgb(', '')
+          .replaceAll(')', '')
+          .replaceAll(' ', '');
+      final rgb = backgroundColor.split(',');
       return {
         'accent': {
           'R': int.parse(rgb[0]),
@@ -40,7 +40,7 @@ class SystemThemeWeb {
         }
       };
     }
-    
+
     return null;
   }
 }

--- a/test/system_theme_test.dart
+++ b/test/system_theme_test.dart
@@ -13,7 +13,7 @@ void main() {
       expect(kDefaultFallbackColor.toString(), color);
     });
   });
-  
+
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);

--- a/test/system_theme_test.dart
+++ b/test/system_theme_test.dart
@@ -8,29 +8,12 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (methodCall) async {
-      switch (methodCall.method) {
-        case kGetSystemAccentColorMethod:
-          return kDefaultFallbackColor.toString();
-        case kGetDarkModeMethod:
-          return false;
-        default:
-          return null;
-      }
+    test('Get accent color', () async {
+      final color = await channel.invokeMethod(kGetSystemAccentColorMethod);
+      expect(kDefaultFallbackColor.toString(), color);
     });
   });
-
-  test('Get accent color', () async {
-    final color = await channel.invokeMethod(kGetSystemAccentColorMethod);
-    expect(kDefaultFallbackColor.toString(), color);
-  });
-
-  test('Check dark mode', () async {
-    final darkMode = await channel.invokeMethod(kGetDarkModeMethod);
-    expect(false, darkMode);
-  });
-
+  
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);

--- a/windows/system_theme_plugin.cpp
+++ b/windows/system_theme_plugin.cpp
@@ -61,42 +61,31 @@ namespace {
     SystemThemePlugin::~SystemThemePlugin() {}
 
     void SystemThemePlugin::HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue> &method_call, std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-        if (method_call.method_name() == "SystemTheme.darkMode") {
-            bool darkMode = false;
-            windows10colors::GetAppDarkModeEnabled(darkMode);
-            result->Success(flutter::EncodableValue(darkMode));
-        }
-        else if (method_call.method_name() == "SystemTheme.accentColor") {
-            windows10colors::AccentColor accentColors;
-            windows10colors::GetAccentColor(accentColors);
-            flutter::EncodableMap colors = flutter::EncodableMap();
-            colors[flutter::EncodableValue("accent")] = flutter::EncodableValue(
-                getRGBA(accentColors.accent)
-            );
-            colors[flutter::EncodableValue("light")] = flutter::EncodableValue(
-                getRGBA(accentColors.light)
-            );
-            colors[flutter::EncodableValue("lighter")] = flutter::EncodableValue(
-                getRGBA(accentColors.lighter)
-            );
-            colors[flutter::EncodableValue("lightest")] = flutter::EncodableValue(
-                getRGBA(accentColors.lightest)
-            );
-            colors[flutter::EncodableValue("dark")] = flutter::EncodableValue(
-                getRGBA(accentColors.dark)
-            );
-            colors[flutter::EncodableValue("darker")] = flutter::EncodableValue(
-                getRGBA(accentColors.darker)
-            );
-            colors[flutter::EncodableValue("darkest")] = flutter::EncodableValue(
-                getRGBA(accentColors.darkest)
-            );
-            result->Success(flutter::EncodableValue(colors));
-        }
-        else {
-            result->NotImplemented();
-        }
-    }
+        windows10colors::AccentColor accentColors;
+        windows10colors::GetAccentColor(accentColors);
+        flutter::EncodableMap colors = flutter::EncodableMap();
+        colors[flutter::EncodableValue("accent")] = flutter::EncodableValue(
+            getRGBA(accentColors.accent)
+        );
+        colors[flutter::EncodableValue("light")] = flutter::EncodableValue(
+            getRGBA(accentColors.light)
+        );
+        colors[flutter::EncodableValue("lighter")] = flutter::EncodableValue(
+            getRGBA(accentColors.lighter)
+        );
+        colors[flutter::EncodableValue("lightest")] = flutter::EncodableValue(
+            getRGBA(accentColors.lightest)
+        );
+        colors[flutter::EncodableValue("dark")] = flutter::EncodableValue(
+            getRGBA(accentColors.dark)
+        );
+        colors[flutter::EncodableValue("darker")] = flutter::EncodableValue(
+            getRGBA(accentColors.darker)
+        );
+        colors[flutter::EncodableValue("darkest")] = flutter::EncodableValue(
+            getRGBA(accentColors.darkest)
+        );
+        result->Success(flutter::EncodableValue(colors));
 
 }
 


### PR DESCRIPTION
Given that the darkmode platform method's invoke have been removed, replaced by the flutter `dart:ui.PlatformDispatcher` class, the implements codes are unused and unnecessary to support this package.

ptal.