### PR TITLE
Fix failure related to namespace when upgrading to AGP 8 and newer

### DIFF
--- a/system_theme/android/build.gradle
+++ b/system_theme/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.bruno.system_theme'
     compileSdkVersion 31
 
     sourceSets {

--- a/system_theme/android/build.gradle
+++ b/system_theme/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.bruno.system_theme'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         jcenter()

--- a/system_theme/example/android/build.gradle
+++ b/system_theme/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This PR fixes application build failure (or well... in the screenshot below - config failure) when attempting to compile a project using AGP 8 and newer by specifying the namespace as required by https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl

![image](https://github.com/user-attachments/assets/8d47328c-09bb-4f65-8df2-4d2e420fe7d4)
