### PR TITLE
fix: Allow dependency to be use with Gradle 9

### DIFF
--- a/system_theme/android/build.gradle
+++ b/system_theme/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.7.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This will allow the dependency to be use with Gradle 9

Gradle 9 removed option to use JCenter repository, a better option is to migrate to MavenCentral which 

Tested with Gradle 9.3.1 by compiling and running a Android project with this changes on Pixel 7 Android 17 Beta 2